### PR TITLE
Include scalar specifiedBy URL in introspection

### DIFF
--- a/src/Introspector.php
+++ b/src/Introspector.php
@@ -29,9 +29,15 @@ class Introspector
         $client = $this->endpointConfig->makeClient();
 
         try {
-            $introspectionResult = $this->fetchIntrospectionResult($client, true);
+            $introspectionResult = $this->fetchIntrospectionResult($client, [
+                'directiveIsRepeatable' => true,
+                'specifiedByURL' => true,
+            ]);
         } catch (\Throwable $_) {
-            $introspectionResult = $this->fetchIntrospectionResult($client, false);
+            $introspectionResult = $this->fetchIntrospectionResult($client, [
+                'directiveIsRepeatable' => false,
+                'specifiedByURL' => false,
+            ]);
         }
 
         $schema = BuildClientSchema::build(
@@ -47,12 +53,11 @@ class Introspector
         );
     }
 
-    protected function fetchIntrospectionResult(Client $client, bool $directiveIsRepeatable): Response
+    /** @param array<string, bool> $introspectionQueryOptions */
+    protected function fetchIntrospectionResult(Client $client, array $introspectionQueryOptions): Response
     {
         $response = $client->request(
-            Introspection::getIntrospectionQuery([
-                'directiveIsRepeatable' => $directiveIsRepeatable,
-            ])
+            Introspection::getIntrospectionQuery($introspectionQueryOptions)
         );
 
         if (isset($response->errors)) {

--- a/src/Introspector.php
+++ b/src/Introspector.php
@@ -53,7 +53,15 @@ class Introspector
         );
     }
 
-    /** @param array<string, bool> $introspectionQueryOptions */
+    /**
+     * @param array{
+     *     descriptions?: bool,
+     *     directiveIsRepeatable?: bool,
+     *     schemaDescription?: bool,
+     *     specifiedByURL?: bool,
+     *     typeIsOneOf?: bool,
+     * } $introspectionQueryOptions
+     */
     protected function fetchIntrospectionResult(Client $client, array $introspectionQueryOptions): Response
     {
         $response = $client->request(


### PR DESCRIPTION
## Summary
Request scalar `specifiedByURL` in the primary introspection query and pass introspection options as an options array so fallback behavior stays explicit.